### PR TITLE
Add exposeTextAs option for pegjs text()

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,5 @@ Some configuration is available, passed to PEG.buildParser in the
 
 * `keepUndefined` if `true`, does not eliminate key-value pairs where
    the value is `null` or `undefined`.
+
+* `exposeTextAs` if set to a string `s`, adds a key-value pair (`s`, `text()`), where [`text()` is the entire string that was matched](https://github.com/pegjs/pegjs/tree/v0.8.0#expression--action-)

--- a/spec/PegjsBonsaiSpec.js
+++ b/spec/PegjsBonsaiSpec.js
@@ -75,4 +75,12 @@ describe("Bonsai", function () {
         });
     });
 
+    describe("behavior of exposeTextAs option", function () {
+        it("when set to a string, sets PEG's text() as the value of that property", function () {
+            var parser = PEG.buildParser("rule = first:'one' ' '? second:'two'?", {plugins:[bonsai], bonsaiPlugin:{ exposeTextAs:'$text' }});
+            expect(parser.parse('one two')).toEqual({first: 'one', second: 'two', $text: 'one two'});
+            expect(parser.parse('one')).toEqual({first: 'one', $text: 'one'});
+        });
+    });
+
 });

--- a/src/index.js
+++ b/src/index.js
@@ -16,16 +16,19 @@ exports.pass = function(ast, options) {
         return arr;
     }
 
-    function generate_code_without_undefined(labels) {
+    function generate_code(labels) {
         return ['\n  var val = {};']
             .concat(labels.map(function(label) {
-                return '  if (' + label + ' !== undefined && ' + label + ' !== null) val["' + label + '"] = ' + label + ';';
+                var code = '  ';
+                if (!myOptions.keepUndefined) {
+                    code += 'if (' + label + ' !== undefined && ' + label + ' !== null) ';
+                }
+                code += 'val["' + label + '"] = ' + label + ';';
+                return code;
             }))
             .concat('  return val;')
             .join('\n');
     }
-
-    var generate_code = generate_code_without_undefined;
 
     function process_expression(exp, stack) {
         var stack_plus = stack.concat(exp);
@@ -69,13 +72,6 @@ exports.pass = function(ast, options) {
 
     // Here is the actual body of the 'pass' function:
     myOptions = options.bonsaiPlugin ? options.bonsaiPlugin : {};
-    if (myOptions.keepUndefined) {
-        generate_code = function(labels) {
-            return 'return {' + 
-                labels.map(function(l) { return '"' + l + '":' + l; }).join(',') +
-                    ' };';
-        };
-    }
     ast.rules = ast.rules.map(process_rule);
     if (myOptions.showTransformed) {
         console.log(JSON.stringify(ast.rules, null, 2));

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,12 @@ exports.pass = function(ast, options) {
                 code += 'val["' + label + '"] = ' + label + ';';
                 return code;
             }))
+            .concat(function () {
+                if (myOptions.exposeTextAs) {
+                  return '  val["' + myOptions.exposeTextAs + '"] = text();';
+                }
+                return '';
+            }())
             .concat('  return val;')
             .join('\n');
     }


### PR DESCRIPTION
(resolves #2 since it's built on top of it)

I'm working on a [project](https://github.com/joseph-onsip/abnf-ast/tree/serialize-bonsai-exposeTextAs) that automatically generates a PEG.js grammar from the corresponding ABNF, with the idea being that the resulting parser will return an AST. `pegjs-bonsai` works quite well for the AST-generation, but I'd also like to have the option to access the original `text()` matched by PEG.js.

I've put together an example that uses the ABNF definition of ABNF to generate a PEG.js grammar, then builds a parser from said grammar (including `pegjs-bonsai` with my proposed change) and uses it to parse the original ABNF. If you run the following, you'll see extra "$text" nodes in the output:

``` shell
cd /tmp
npm install joseph-onsip/abnf-ast#serialize-bonsai-exposeTextAs
cd node_modules/abnf-ast/
npm install && npm test
```

Does this sound like a reasonable change to make?
